### PR TITLE
Supplying members with an arn causes conflict

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "aws_shield_protection_group" "this" {
   aggregation         = each.value.aggregation
   pattern             = each.value.pattern
   resource_type       = each.value.resource_type
-  members             = try([var.resource_arn], [])
+  members             = (each.value.pattern == "ARBITARY" ? try([var.resource_arn], []) : null)
   tags = merge(
     local.tags,
     var.tags

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "aws_shield_protection_group" "this" {
   aggregation         = each.value.aggregation
   pattern             = each.value.pattern
   resource_type       = each.value.resource_type
-  members             = (each.value.pattern == "ARBITARY" ? try([var.resource_arn], []) : null)
+  members             = (each.value.pattern == "ARBITRARY" ? try([var.resource_arn], []) : null)
   tags = merge(
     local.tags,
     var.tags


### PR DESCRIPTION
Hit this when trying to use this module for an ALB arn.

` Error: Conflicting configuration arguments
 
with aws_shield_protection_group.this["ALB-Protection"],
  on main.tf line 25, in resource "aws_shield_protection_group" "this":
  25:   resource_type       = each.value.resource_type
 "resource_type": conflicts with members`

According to the [docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-shield-protectiongroup.html), you cant supply members when using a pattern other than ARBITRARY

